### PR TITLE
Upgrade to PhantomJS 1.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "mocha-phantomjs": "mobify/mocha-phantomjs",
+    "mocha-phantomjs": "mobify/mocha-phantomjs#upgrade-to-1.9.8",
     "phantomjs": "1.9.8",
     "lodash": "2.4.1",
     "async": "~0.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "mocha-phantomjs": "mobify/mocha-phantomjs",
-    "phantomjs": "1.9.7-15",
+    "phantomjs": "1.9.8",
     "lodash": "2.4.1",
     "async": "~0.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "mocha-phantomjs": "mobify/mocha-phantomjs#upgrade-to-1.9.8",
-    "phantomjs": "1.9.8",
+    "phantomjs": "1.9.20",
     "lodash": "2.4.1",
     "async": "~0.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "mocha-phantomjs": "mobify/mocha-phantomjs#upgrade-to-1.9.8",
+    "mocha-phantomjs": "mobify/mocha-phantomjs",
     "phantomjs": "1.9.20",
     "lodash": "2.4.1",
     "async": "~0.2"


### PR DESCRIPTION
Upgrades this Mobify fork to point to phantomjs `1.9.20` (which installs version `1.9.8` of the phantomjs binary). 

Tested on: https://github.com/mobify/extra-mobile/pull/111
